### PR TITLE
WIP: restart stats middleware

### DIFF
--- a/stats/stats.go
+++ b/stats/stats.go
@@ -1,0 +1,27 @@
+package stats
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/armon/go-metrics"
+	"github.com/goadesign/goa"
+)
+
+// Reporter is a middleware that reports statistics to any sink
+// supported by github.com/armon/go-metrics, which currently
+// includes statsd, prometheus and others
+func Reporter(sink metrics.MetricSink) goa.Middleware {
+	return func(h goa.Handler) goa.Handler {
+		return func(ctx *goa.Context) error {
+			start := time.Now()
+			err := h(ctx)
+			r := ctx.Request()
+			key := fmt.Sprintf("%s_%s", r.Method, r.URL.String())
+			metrics.MeasureSince([]string{key}, start)
+			return err
+		}
+
+	}
+
+}


### PR DESCRIPTION
This PR adds a middleware that reports stats to the armon/go-stats package, which can either be scraped by prometheus, or publish to statsd and more.  This seems to be the most flexible option to allow metrics reporting without binding the end user to a specific platform.

- [x] Write Middleware
- [ ] Write Tests
- [ ] Complete documentation and examples