### PR TITLE
Recover() middleware - joining lines back together for easier parsing of stack trace

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -165,7 +165,7 @@ func Recover() goa.Middleware {
 									http.StatusText(status),
 									reqID)
 							}
-							ctx.Logger.Error("panic", "err", err, "stack", stack)
+							ctx.Logger.Error("panic", "err", err, "stack", strings.Join(stack, "\n"))
 						}
 
 						// note we must respond or else a 500 with "unhandled request" is the


### PR DESCRIPTION
Otherwise, the lines get serialized as a Go slice with a space between each entry, making it ambiguous to parse.